### PR TITLE
Simple hack to display multiple instances

### DIFF
--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -69,7 +69,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, args: Args, composition:
     let mut transform = Affine::scale(args.scale.unwrap_or(1.0));
     let mut mouse_down = false;
     let mut prior_position: Option<Vec2> = None;
-    let mut n = 1;
+    let mut n = 1u32;
     event_loop.run(move |event, _, control_flow| match event {
         Event::WindowEvent {
             ref event,
@@ -82,8 +82,14 @@ async fn run(event_loop: EventLoop<()>, window: Window, args: Args, composition:
                         Some(VirtualKeyCode::Escape) => {
                             *control_flow = ControlFlow::Exit;
                         }
-                        Some(VirtualKeyCode::X) => n += 1,
-                        Some(VirtualKeyCode::Z) => n = (n - 1).max(1),
+                        Some(VirtualKeyCode::X) => {
+                            n = (n * 2).min(256);
+                            println!("n = {n}");
+                        }
+                        Some(VirtualKeyCode::Z) => {
+                            n = (n / 2).max(1);
+                            println!("n = {n}");
+                        }
                         _ => {}
                     }
                 }
@@ -141,8 +147,13 @@ async fn run(event_loop: EventLoop<()>, window: Window, args: Args, composition:
             let time = start.elapsed().as_secs_f32();
 
             let mut builder = SceneBuilder::for_scene(&mut scene);
+            let nx = 1 << (n.ilog2() / 2);
             for i in 0..n {
-                let new_t = transform * Affine::translate((0.0, i as f64 * 300.0));
+                let x = i % nx;
+                let y = i / nx;
+                let sx = (10000.0 / nx as f64).min(1000.0);
+                let sy = (10000.0 * nx as f64 / n as f64).min(1000.0);
+                let new_t = transform * Affine::translate((x as f64 * sx, y as f64 * sy));
                 let new_time = time + i as f32 * 0.25;
                 velato_renderer.render(&composition, new_time, new_t, 1.0, &mut builder);
             }
@@ -159,7 +170,7 @@ async fn run(event_loop: EventLoop<()>, window: Window, args: Args, composition:
                     &scene,
                     &surface_texture,
                     &RenderParams {
-                        base_color: args.base_color.unwrap_or(Color::BLACK),
+                        base_color: args.base_color.unwrap_or(Color::WHITE),
                         width,
                         height,
                     },


### PR DESCRIPTION
Use the "x" key to show more copies, "z" key to show fewer. It's limited to 256 at the moment as I find there are artifacts with more instances. This is hacky and pretty much made just for demo purposes, so not sure whether I want to check it in just yet.