### PR TITLE
Fixes for errors in bodymovin-rs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ vello = { git = "https://github.com/linebender/vello", rev = "17096ad878dcdfdc95
 
 [dependencies]
 vello = { workspace = true }
-bodymovin = { git = "https://github.com/dfrg/bodymovin-rs", rev = "c156dda9" }
+bodymovin = { git = "https://github.com/vectorgameexperts/bodymovin-rs" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition.workspace = true
 repository.workspace = true
 
 [workspace.dependencies]
-vello = { git = "https://github.com/linebender/vello", rev = "17096ad878dcdfdc954239d5da782732303b1349" }
+vello = { git = "https://github.com/linebender/vello", rev = "b0303ccf98df15a8b196272720d364a56f7304ba" }
 
 
 [dependencies]

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -16,7 +16,7 @@ vello = { workspace = true, features = ["buffer_labels"] }
 anyhow = "1.0"
 clap = { version = "4.1", features = ["derive"] }
 
-wgpu = "0.16.0"
+wgpu = "0.16"
 winit = "0.28.1"
 pollster = "0.3"
 env_logger = "0.10.0"

--- a/demo/Cargo.toml
+++ b/demo/Cargo.toml
@@ -16,7 +16,7 @@ vello = { workspace = true, features = ["buffer_labels"] }
 anyhow = "1.0"
 clap = { version = "4.1", features = ["derive"] }
 
-wgpu = "0.15"
+wgpu = "0.16.0"
 winit = "0.28.1"
 pollster = "0.3"
 env_logger = "0.10.0"

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,6 +1,8 @@
 // Copyright 2023 Google LLC
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
+use crate::model::animated::Position;
+
 use super::{model, model::*, Composition};
 
 use vello::kurbo::{Point, Size, Vec2};
@@ -146,7 +148,17 @@ fn setup_layer<T>(
 fn conv_transform(value: &bodymovin::helpers::Transform) -> (Transform, Value<f32>) {
     let transform = animated::Transform {
         anchor: conv_point(&value.anchor_point),
-        position: conv_point(&value.position),
+        position: match &value.position {
+            bodymovin::properties::SplittableMultiDimensional::Uniform(position) => {
+                Position::Point(conv_point(position))
+            }
+            bodymovin::properties::SplittableMultiDimensional::Split(split_vector) => {
+                Position::SplitComponents((
+                    conv_scalar(&split_vector.x_component),
+                    conv_scalar(&split_vector.y_component),
+                ))
+            }
+        },
         scale: conv_vec2(&value.scale),
         rotation: conv_scalar(&value.rotation),
         skew: conv_scalar(&value.skew),
@@ -159,7 +171,7 @@ fn conv_transform(value: &bodymovin::helpers::Transform) -> (Transform, Value<f3
 fn conv_shape_transform(value: &bodymovin::shapes::Transform) -> GroupTransform {
     let transform = animated::Transform {
         anchor: conv_point(&value.anchor_point),
-        position: conv_point(&value.position),
+        position: Position::Point(conv_point(&value.position)),
         scale: conv_vec2(&value.scale),
         rotation: conv_scalar(&value.rotation),
         skew: conv_scalar(&value.skew),


### PR DESCRIPTION
Several lotties can't play in Velato due to some errors in how things are parsed or handled.
We had to open a fork to bodymovin-rs to fix a few of those errors, so I hope you don't mind us moving to our fork.

For example issues, see #4 

This PR allows for more animations to play, but it's still not bulletproof. Some frames on some animations now flicker or have opacity issues, but that was beyond reasoning with.

Point is, this allows for more things to play that wouldn't before, and does not hurt backwards compatibility to my knowledge.