### PR TITLE
Update git hash

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,4 +27,4 @@ vello = { git = "https://github.com/linebender/vello.git", rev = "34d313d0decc6c
 
 [dependencies]
 vello = { workspace = true }
-bodymovin = { git = "https://github.com/vectorgameexperts/bodymovin-rs" }
+bodymovin = { git = "https://github.com/Traverse-Research/bodymovin-rs.git" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ edition.workspace = true
 repository.workspace = true
 
 [workspace.dependencies]
-vello = { git = "https://github.com/linebender/vello", rev = "b0303ccf98df15a8b196272720d364a56f7304ba" }
+vello = { git = "https://github.com/linebender/vello.git", rev = "34d313d0decc6c3ddbb9185195356ce5accde305", default-features = false }
 
 
 [dependencies]


### PR DESCRIPTION
This bumps the hash of to one later in `vello`.

It also specifies `default-features = false` so we can use this project without `wgpu` on our end.