### PR TITLE
Standardize copyright headers.

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,7 @@
+# This is the list of Velato's significant contributors.
+#
+# This does not necessarily list everyone who has contributed code,
+# especially since many employees of one corporation may be contributing.
+# To see the full list of contributors, see the revision history in
+# source control.
+Google LLC

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,9 +6,7 @@ members = ["demo"]
 edition = "2021"
 version = "0.0.1"
 license = "MIT OR Apache-2.0"
-# homepage = "https://vello.dev" - Domain owned by us, but unused at present
-# rust-version = 
-repository = "https://github.com/linebender/vello"
+repository = "https://github.com/linebender/velato"
 
 [package]
 name = "velato"

--- a/demo/src/main.rs
+++ b/demo/src/main.rs
@@ -1,18 +1,5 @@
-// Copyright 2022 Google LLC
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     https://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-//
-// Also licensed under MIT license, at your choice.
+// Copyright 2022 the Velato Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use std::{fs, time::Instant};
 

--- a/src/import.rs
+++ b/src/import.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2023 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use crate::model::animated::Position;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2023 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /// Re-export vello.

--- a/src/model/animated.rs
+++ b/src/model/animated.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2023 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /*!

--- a/src/model/fixed.rs
+++ b/src/model/fixed.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2023 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 /*!

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2023 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use vello::kurbo::{self, Affine, PathEl, Point, Shape as _, Size, Vec2};

--- a/src/model/spline.rs
+++ b/src/model/spline.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2023 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use vello::kurbo::{PathEl, Point};

--- a/src/model/value.rs
+++ b/src/model/value.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2023 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use vello::kurbo;

--- a/src/render.rs
+++ b/src/render.rs
@@ -1,4 +1,4 @@
-// Copyright 2023 Google LLC
+// Copyright 2023 the Velato Authors
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
 use super::{model::*, Composition};


### PR DESCRIPTION
The Linebender standard for copyright headers was decided last year in [kurbo#207](https://github.com/linebender/kurbo/issues/207) as the following:

```
// Copyright <year of file creation> the <Project> Authors
// SPDX-License-Identifier: Apache-2.0 OR MIT
```

This PR converts all file headers to this standard form and adds an `AUTHORS` file to record significant contributors.