### PR TITLE
Replace vello's default `wgpu` feature with an optional `vello-wgpu` feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 ## Unreleased
 
+- Disable `vello`'s default `wgpu` feature, and provide a `wgpu` passthrough feature to turn it back on. ([#17](https://github.com/linebender/velato/pull/17))
+
 ## 0.1.0 (2024-03-26)
 
 - Initial release

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ repository.workspace = true
 
 [workspace.dependencies]
 # NOTE: Make sure to keep this in sync with the version badge in README.md
-vello = "0.1.0"
+vello = { version = "0.1.0", default-features = false }
 
 [dependencies]
 vello = { workspace = true }
@@ -33,3 +33,7 @@ serde_repr = "0.1.18"
 
 [target.'cfg(target_arch = "wasm32")'.dev-dependencies]
 wasm-bindgen-test = "0.3.42"
+
+[features]
+# Enables the wgpu feature on vello, which is disabled by default
+wgpu = ["vello/wgpu"]

--- a/examples/with_winit/Cargo.toml
+++ b/examples/with_winit/Cargo.toml
@@ -17,7 +17,7 @@ name = "with_winit_bin"
 path = "src/main.rs"
 
 [dependencies]
-vello = { workspace = true, features = ["buffer_labels", "wgpu-profiler"] }
+vello = { workspace = true, features = ["buffer_labels", "wgpu", "wgpu-profiler"] }
 scenes = { path = "../scenes" }
 anyhow = "1"
 clap = { version = "4.5.1", features = ["derive"] }
@@ -30,7 +30,7 @@ env_logger = "0.11.2"
 log = "0.4.21"
 
 [target.'cfg(not(any(target_arch = "wasm32", target_os = "android")))'.dependencies]
-vello = { workspace = true, features = ["hot_reload", "wgpu-profiler"] }
+vello = { workspace = true, features = ["hot_reload", "wgpu", "wgpu-profiler"] }
 notify-debouncer-mini = "0.3"
 
 [target.'cfg(target_os = "android")'.dependencies]


### PR DESCRIPTION
https://github.com/linebender/vello/pull/359 made `wgpu` an optional but default dependency/feature, but any crate using `velato` will be forced to opt in to `wgpu` due to not disabling the default here.

Since `velato` does not need any rendering backend at all, this feature should be disabled by default.  As the `vello` crate is reexported from the root, a `vello-wgpu` passthrough feature is provided so that users can turn it back on without explicitly depending on `vello` in their crate dependencies.

---

Note that `with_winit` runs briefly (with `wgpu`), but if I don't manage to immediately fullscreen it, it panics:

```
thread 'main' panicked at examples/with_winit/src/lib.rs:436:30:
failed to get surface texture: Timeout
```

This is on a Wayland compositor with AMD GPU. I'm not a WGPU expert and don't dare to immediately say where it is being used wrong.
