### PR TITLE
example: Fix wrong `target_os` check.

### DIFF
--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -44,12 +44,10 @@ struct Args {
 }
 
 fn default_threads() -> usize {
-    #![allow(unreachable_code)]
-    #[cfg(target_os = "mac")]
-    {
-        return 1;
-    }
-    0
+    #[cfg(target_os = "macos")]
+    return 1;
+    #[cfg(not(target_os = "macos"))]
+    return 0;
 }
 
 struct RenderState<'s> {


### PR DESCRIPTION
Bring over the new version of this function from `vello`.