### PR TITLE
Match CI doc testing with docs.rs.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -306,15 +306,17 @@ jobs:
         with:
           save-if: ${{ github.event_name != 'merge_group' }}
 
-      # We test documentation using nightly to match docs.rs. This prevents potential breakages
+      # We test documentation using nightly to match docs.rs.
       - name: cargo doc
-        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items -Zunstable-options -Zrustdoc-scrape-examples
+        run: cargo doc --workspace --locked --all-features --no-deps --document-private-items
+        env:
+          RUSTDOCFLAGS: '--cfg docsrs -D warnings'
 
-  # If this fails, consider changing your text or adding something to .typos.toml
+  # If this fails, consider changing your text or adding something to .typos.toml.
   typos:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
 
       - name: check typos
-        uses: crate-ci/typos@v1.26.0
+        uses: crate-ci/typos@v1.27.0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,12 @@ license.workspace = true
 edition.workspace = true
 repository.workspace = true
 
+[package.metadata.docs.rs]
+all-features = true
+# There are no platform specific docs.
+default-target = "x86_64-unknown-linux-gnu"
+targets = []
+
 [workspace.lints]
 clippy.doc_markdown = "warn"
 clippy.semicolon_if_nothing_returned = "warn"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,8 +5,8 @@
 //!
 //! This currently lacks support for a [number of important](crate#unsupported-features) SVG features.
 //!
-//! This is also intended to be the preferred integration between Vello and [usvg], so [consider
-//! contributing](https://github.com/linebender/vello_svg) if you need a feature which is missing.
+//! This is also intended to be the preferred integration between Vello and [usvg](https://crates.io/crates/usvg),
+//! so [consider contributing](https://github.com/linebender/vello_svg) if you need a feature which is missing.
 //!
 //! This crate also re-exports [`vello`], so you can easily use the specific version that is compatible with Velato.
 //!
@@ -44,6 +44,8 @@
 //! - Correct color stop handling
 //! - Split rotations
 //! - Split positions
+
+#![cfg_attr(docsrs, feature(doc_auto_cfg))]
 
 pub(crate) mod import;
 pub(crate) mod runtime;


### PR DESCRIPTION
* Remove `-Zunstable-options -Zrustdoc-scrape-examples` from CI. It wasn't even enabled for docs.rs and we don't have any examples as defined by Cargo, so not worth enabling scraping at this point.
* Treat doc warnings as errors. Historically we've not done so due to various `rustdoc` bugs giving false positives but I got it to pass without failure right now, so perhaps better times have arrived.
* Enable the `doc_auto_cfg` feature for docs.rs which will show a little tip next to feature gated functionality informing of the crate feature flag.
* Pass `--all-features` at docs.rs to match our CI and reduce the maintenance burden of manually syncing the features list.
* Target only `x86_64-unknown-linux-gnu` on docs.rs as we don't have any platform specific docs.