### PR TITLE
Update the link to lottie spec on README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # Velato
 
-**An integration to parse and render [Lottie](https://airbnb.io/lottie) with [Vello](https://vello.dev).**
+**An integration to parse and render [Lottie](https://lottie.github.io/) with [Vello](https://vello.dev).**
 
 [![Linebender Zulip](https://img.shields.io/badge/Linebender-%23gpu-blue?logo=Zulip)](https://xi.zulipchat.com/#narrow/stream/197075-gpu)
 [![dependency status](https://deps.rs/repo/github/linebender/velato/status.svg)](https://deps.rs/repo/github/linebender/velato)


### PR DESCRIPTION
Currently, the link refers to https://airbnb.io/lottie, but it seems https://lottie.github.io/ contains more information. I'm very new to lottie, so, honestly, I'm not sure which is more appropriate, but I found ~~the former~~(the latter) is more convenient because it contains the link to the format specifications.