### PR TITLE
Added discontinuous path keyframes & optional last spline keyframe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,11 @@ Subheadings to categorize changes are `added, changed, deprecated, removed, fixe
 
 This release has an [MSRV][] of 1.82.
 
+### Added
+
+- Keyframes in an animated Spline may now specify an `"e"` key, dictating an end value. When specified, this value is used instead of the next keyframe's start value, allowing for discontinuous animations. ([#60] by [@RishiChalla])
+- The last keyframe in an animated Spline may now specify only the timestamp, omitting all other fields. In this scenario, the previous keyframe's end/start values will be used. ([#60] by [@RishiChalla])
+
 ## [0.5.0]  - 2025-02-02
 
 This release has an [MSRV][] of 1.82.

--- a/src/import/converters.rs
+++ b/src/import/converters.rs
@@ -602,12 +602,16 @@ pub fn conv_shape_geometry(
                 let start_bezier = {
                     if let Some(start) = &value.start {
                         start.first()?.clone()
-                    } else { // No keyframe was present - we look for the previous end/start
+                    } else {
+                        // No keyframe was present - we look for the previous end/start
                         let prev = animated.get(idx - 1)?;
                         // Take the previous end if present, otherwise the previous start.
                         if let Some(prev_end) = prev.end.as_ref() {
-                            if let Some(prev_end_bezier) = prev_end.first() { prev_end_bezier.clone() }
-                            else { prev.start.as_ref()?.first()?.clone() }
+                            if let Some(prev_end_bezier) = prev_end.first() {
+                                prev_end_bezier.clone()
+                            } else {
+                                prev.start.as_ref()?.first()?.clone()
+                            }
                         } else {
                             prev.start.as_ref()?.first()?.clone()
                         }
@@ -615,12 +619,12 @@ pub fn conv_shape_geometry(
                 };
                 let (points, is_frame_closed) = conv_spline(&start_bezier);
                 // Get converted spline points for keyframe bezier at the end
-                let end_points = value.end.as_ref().map(|end_beziers| {
+                let end_points = value.end.as_ref().and_then(|end_beziers| {
                     let end_bezier = end_beziers.first()?;
                     let (end_points, is_end_frame_closed) = conv_spline(end_bezier);
                     is_closed |= is_end_frame_closed;
                     Some(end_points)
-                }).flatten();
+                });
                 // Add the keyframe values
                 values.push(animated::SplineKeyframeValues {
                     start: points,

--- a/src/import/converters.rs
+++ b/src/import/converters.rs
@@ -579,23 +579,53 @@ pub fn conv_shape_geometry(
             Some(runtime::model::Geometry::Fixed(path))
         }
         Animated(animated) => {
+            // Build frames & values for the animated spline
             let mut frames = vec![];
             let mut values = vec![];
-            for value in animated {
+
+            for (idx, value) in animated.iter().enumerate() {
+                // Extract hold from base key properties
                 let hold = value
                     .base
                     .hold
                     .as_ref()
                     .map(|b| b.eq(&BoolInt::True))
                     .unwrap_or(false);
+                // Add frame time and easing
                 frames.push(Time {
                     frame: value.base.time,
                     in_tangent: value.base.in_tangent.as_ref().map(conv_keyframe_handle),
                     out_tangent: value.base.out_tangent.as_ref().map(conv_keyframe_handle),
                     hold,
                 });
-                let (points, is_frame_closed) = conv_spline(value.start.first()?);
-                values.push(points);
+                // Get converted spline points for keyframe bezier at the start
+                let start_bezier = {
+                    if let Some(start) = &value.start {
+                        start.first()?.clone()
+                    } else { // No keyframe was present - we look for the previous end/start
+                        let prev = animated.get(idx - 1)?;
+                        // Take the previous end if present, otherwise the previous start.
+                        if let Some(prev_end) = prev.end.as_ref() {
+                            if let Some(prev_end_bezier) = prev_end.first() { prev_end_bezier.clone() }
+                            else { prev.start.as_ref()?.first()?.clone() }
+                        } else {
+                            prev.start.as_ref()?.first()?.clone()
+                        }
+                    }
+                };
+                let (points, is_frame_closed) = conv_spline(&start_bezier);
+                // Get converted spline points for keyframe bezier at the end
+                let end_points = value.end.as_ref().map(|end_beziers| {
+                    let end_bezier = end_beziers.first()?;
+                    let (end_points, is_end_frame_closed) = conv_spline(end_bezier);
+                    is_closed |= is_end_frame_closed;
+                    Some(end_points)
+                }).flatten();
+                // Add the keyframe values
+                values.push(animated::SplineKeyframeValues {
+                    start: points,
+                    end: end_points,
+                });
                 is_closed |= is_frame_closed;
             }
             Some(runtime::model::Geometry::Spline(animated::Spline {

--- a/src/runtime/model/animated.rs
+++ b/src/runtime/model/animated.rs
@@ -209,8 +209,11 @@ impl Spline {
             return false;
         };
         let to_slice = {
-            if let Some(end) = &from.end { end.as_slice() }
-            else { to.start.as_slice() }
+            if let Some(end) = &from.end {
+                end.as_slice()
+            } else {
+                to.start.as_slice()
+            }
         };
         (from.start.as_slice(), to_slice, t).to_path(self.is_closed, path);
         true

--- a/src/runtime/model/animated.rs
+++ b/src/runtime/model/animated.rs
@@ -184,8 +184,16 @@ pub struct Spline {
     pub is_closed: bool,
     /// Collection of times.
     pub times: Vec<Time>,
-    /// Collection of splines.
-    pub values: Vec<Vec<Point>>,
+    /// Collection of splines for each time. The splines at each point must have a start, but may also have an
+    /// end defined. When the end is not defined, then the next keyframe's start is used.
+    pub values: Vec<SplineKeyframeValues>,
+}
+
+/// The values of an animated Spline at a single keyframe. When end is None, the next frame's start is used.
+#[derive(Clone, Debug)]
+pub struct SplineKeyframeValues {
+    pub start: Vec<Point>,
+    pub end: Option<Vec<Point>>,
 }
 
 impl Spline {
@@ -200,7 +208,11 @@ impl Spline {
         let (Some(from), Some(to)) = (self.values.get(ix0), self.values.get(ix1)) else {
             return false;
         };
-        (from.as_slice(), to.as_slice(), t).to_path(self.is_closed, path);
+        let to_slice = {
+            if let Some(end) = &from.end { end.as_slice() }
+            else { to.start.as_slice() }
+        };
+        (from.start.as_slice(), to_slice, t).to_path(self.is_closed, path);
         true
     }
 }

--- a/src/schema/animated_properties/shape_keyframe.rs
+++ b/src/schema/animated_properties/shape_keyframe.rs
@@ -10,6 +10,16 @@ use serde::{Deserialize, Serialize};
 pub struct ShapeKeyframe {
     #[serde(flatten)]
     pub base: KeyframeBase,
+    /// Starting point of this keyframe. This is required for all keyframes, except the last keyframe.
+    /// The last keyframe may omit this value, in which case the previous keyframe's "e" is used (or "s")
+    /// if not present.
     #[serde(rename = "s")]
-    pub start: Vec<Bezier>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub start: Option<Vec<Bezier>>,
+    /// Ending point of this keyframe. Each keyframe may store it's own end, to allow for non-continuous animations.
+    /// This means the ending point of one frame is not guaranteed to match the starting point of the next.
+    /// This is always optional, and never required.
+    #[serde(rename = "e")]
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub end: Option<Vec<Bezier>>,
 }

--- a/src/schema/animated_properties/shape_property.rs
+++ b/src/schema/animated_properties/shape_property.rs
@@ -45,23 +45,32 @@ where
 {
     // Deserialize the keyframes & handle empty case
     let keyframes = Vec::<ShapeKeyframe>::deserialize(deserializer)?;
-    if keyframes.is_empty() { return Ok(keyframes); }
+    if keyframes.is_empty() {
+        return Ok(keyframes);
+    }
 
     // Validate that all keyframes until the last have a start property
-    if !keyframes[0..(keyframes.len() - 1)].iter().all(|keyframe| keyframe.start.is_some()) {
+    if !keyframes[0..(keyframes.len() - 1)]
+        .iter()
+        .all(|keyframe| keyframe.start.is_some())
+    {
         return Err(de::Error::custom(
             "Animated Shape Keyframe found with missing 's' start property. Only the last keyframe may omit this."
         ));
     }
-    
+
     // Early return if last keyframe has a start value.
     if let Some(last_keyframe) = keyframes.last() {
-        if last_keyframe.start.is_some() { return Ok(keyframes); }
+        if last_keyframe.start.is_some() {
+            return Ok(keyframes);
+        }
     }
 
     // The last keyframe has no start value - so there must be at least one other keyframe present.
     if keyframes.len() < 2 {
-        Err(de::Error::custom("Last Animated Shape Keyframe 's' was ommitted where only one keyframe is present."))
+        Err(de::Error::custom(
+            "Last Animated Shape Keyframe 's' was omitted where only one keyframe is present.",
+        ))
     } else {
         Ok(keyframes)
     }

--- a/src/schema/animated_properties/shape_property.rs
+++ b/src/schema/animated_properties/shape_property.rs
@@ -3,6 +3,7 @@
 
 use crate::schema::helpers::bezier::Bezier;
 use crate::schema::helpers::int_boolean::BoolInt;
+use serde::de::{self, Deserializer};
 use serde::{Deserialize, Serialize};
 
 use super::shape_keyframe::ShapeKeyframe;
@@ -22,15 +23,46 @@ pub struct ShapeProperty {
     #[serde(rename = "x")]
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expression: Option<String>,
-    ///
+    /// See [`ShapePropertyK`]
     #[serde(rename = "k")]
     pub value: ShapePropertyK,
 }
 
 /// The possible values of "k" in a [`ShapeProperty`].
+/// Either a static bezier held, or an animation with keyframes defined.
 #[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum ShapePropertyK {
+    #[serde(deserialize_with = "deserialize_keyframes")]
     Animated(Vec<ShapeKeyframe>),
     Static(Bezier),
+}
+
+/// Custom deserializer ensures that every keyframe has a "s" start, except only the last keyframe which may omit this.
+pub fn deserialize_keyframes<'de, D>(deserializer: D) -> Result<Vec<ShapeKeyframe>, D::Error>
+where
+    D: Deserializer<'de>,
+{
+    // Deserialize the keyframes & handle empty case
+    let keyframes = Vec::<ShapeKeyframe>::deserialize(deserializer)?;
+    if keyframes.is_empty() { return Ok(keyframes); }
+
+    // Validate that all keyframes until the last have a start property
+    if !keyframes[0..(keyframes.len() - 1)].iter().all(|keyframe| keyframe.start.is_some()) {
+        return Err(de::Error::custom(
+            "Animated Shape Keyframe found with missing 's' start property. Only the last keyframe may omit this."
+        ));
+    }
+    
+    // Early return if last keyframe has a start value.
+    if let Some(last_keyframe) = keyframes.last() {
+        if last_keyframe.start.is_some() { return Ok(keyframes); }
+    }
+
+    // The last keyframe has no start value - so there must be at least one other keyframe present.
+    if keyframes.len() < 2 {
+        Err(de::Error::custom("Last Animated Shape Keyframe 's' was ommitted where only one keyframe is present."))
+    } else {
+        Ok(keyframes)
+    }
 }


### PR DESCRIPTION
This PR fixes https://github.com/linebender/velato/issues/59

This is my first time contributing to an open-source rust project, so please feel free to criticize code standards / etc! The core issue is that animated splines currently do not support two features causing a panic on deserialization (in my example lottie file provided in the above issue):

1. The "e" key is completely ignored. This key allows for specifying an end to each keyframe's value property. This is particularly useful for creating an discontinuous animation where the last value of a keyframe is not equivalent to the next keyframe's starting point.
2. The last keyframe may be empty, when it is empty the previous keyframe's properties must be used.

I've fixed both these issues with the following changes:

Schema
- Add "e" to schema for end times in each frame, allowing for non-continuous animations
- Make "s" and "e" optional in schema
- Add custom serializing function for The Vec of Keyframes, ensure "s" is always present unless last frame.

Converter
- conv_shape_geometry needs to be updated to support disjointed animations with "e"
- velato::runtime::model::animated::Spline needs to support "e" in each keyframe
- Spline::evaluate needs to support "e" for disjointed animations

With these changes patched into bevy_vello, I was able to render my example lottie (gif below).

![ezgif-8f2c1f5d14d8bd](https://github.com/user-attachments/assets/a5214d68-f546-4e59-81dc-b536d6a5f2c6)

Please let me know if you've got any suggestions or feedback, really appreciate the great rust crates and open source work!