### PR TITLE
publish: Exclude stuff from publish

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,17 @@ license.workspace = true
 edition.workspace = true
 repository.workspace = true
 
+exclude = [
+    ".cargo",
+    ".clippy.toml",
+    ".github",
+    ".gitignore",
+    ".taplo.toml",
+    ".typos.toml",
+    "examples/",
+    "rustfmt.toml",
+]
+
 [package.metadata.docs.rs]
 all-features = true
 # There are no platform specific docs.


### PR DESCRIPTION
This includes various CI metadata as well as the examples directory with the assets.