### PR TITLE
feat: add begin/end_layer_group hooks to RenderSink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ This release has an [MSRV][] of 1.88.
 
 - Added `markers`, `meta` and `metadata` fields to the Animation schema. ([#101][] by [@RobertBrewitz][])
 - Added PolyStar shape support (star and polygon geometry), including animated properties for position, radii, roundness, rotation, and point count. ([#102][] by [@RobertBrewitz][])
+- Added `begin_layer_group`/`end_layer_group` hooks to `RenderSink` for per-layer rendering callbacks. ([#104][] by [@RobertBrewitz][])
 
 ### Fixed
 
@@ -190,6 +191,7 @@ This release has an [MSRV][] of 1.75.
 [#101]: https://github.com/linebender/velato/pull/101
 [#102]: https://github.com/linebender/velato/pull/102
 [#103]: https://github.com/linebender/velato/pull/103
+[#104]: https://github.com/linebender/velato/pull/104
 [#105]: https://github.com/linebender/velato/pull/105
 
 [Unreleased]: https://github.com/linebender/velato/compare/v0.9.0...HEAD

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ You can also load an entire folder or individual files.
 cargo run -p with_winit -- examples/assets
 ```
 
+Run all test scenes with controls:
+
+```shell
+cargo run -p with_winit -- --test-scenes
+```
+
 ### Web platform
 
 Because Vello relies heavily on compute shaders, we rely on the emerging WebGPU standard to run on the web.

--- a/examples/scenes/src/lib.rs
+++ b/examples/scenes/src/lib.rs
@@ -24,6 +24,7 @@
 #[cfg(not(target_arch = "wasm32"))]
 pub mod download;
 mod lottie;
+mod picking;
 mod simple_text;
 mod test_scenes;
 use std::path::PathBuf;
@@ -37,7 +38,7 @@ pub use lottie::{default_scene, scene_from_files};
 pub use simple_text::RobotoText;
 pub use test_scenes::test_scenes;
 
-use kurbo::Vec2;
+use kurbo::{Affine, Vec2};
 use peniko::{Color, color};
 use vello::Scene;
 
@@ -51,6 +52,12 @@ pub struct SceneParams<'a> {
     pub resolution: Option<Vec2>,
     pub base_color: Option<Color>,
     pub complexity: usize,
+    /// Cursor position in window coordinates, if known.
+    pub cursor_position: Option<Vec2>,
+    /// Viewport size in physical pixels.
+    pub viewport_size: Option<Vec2>,
+    /// User camera transform (pan/zoom/rotate) applied to the scene fragment.
+    pub camera_transform: Affine,
 }
 
 pub struct SceneConfig {

--- a/examples/scenes/src/picking.rs
+++ b/examples/scenes/src/picking.rs
@@ -1,0 +1,296 @@
+// Copyright 2026 the Velato Authors
+// SPDX-License-Identifier: Apache-2.0 OR MIT
+
+//! Picking-aware Lottie scene with debug overlays.
+//!
+//! This example demonstrates how to build layer-aware hit-testing on top of
+//! velato using the [`RenderSink`] hooks (`begin_layer_group`/`end_layer_group`).
+//!
+//! The pipeline has four steps:
+//!
+//! 1. **Render** the Lottie animation through a custom [`PickingScene`] sink that
+//!    intercepts draw calls while forwarding them to vello for normal rendering.
+//! 2. **Collect** per-layer axis-aligned bounding boxes (AABBs) from those
+//!    intercepted draw calls.
+//! 3. **Hit-test** the cursor against the collected AABBs, picking the top-most
+//!    layer.
+//! 4. **Draw overlays** — highlight the hovered layer, dim all others, and show a
+//!    tooltip at the cursor.
+
+use std::{collections::HashSet, sync::Arc, time::Instant};
+
+use kurbo::{Affine, Point, Rect, Shape, Vec2};
+use peniko::{BlendMode, Brush, Color, Fill};
+use velato::{Composition, RenderSink, Renderer, model::fixed};
+use vello::Scene;
+
+use crate::SceneParams;
+
+const DEPTH_BAND: usize = 1000;
+const HOVER_FILL: Color = Color::new([1.0, 1.0, 1.0, 0.15]);
+const HOVER_STROKE: Color = Color::new([1.0, 1.0, 1.0, 0.9]);
+const DIM_FILL: Color = Color::new([0.5, 0.5, 0.5, 0.08]);
+const DIM_STROKE: Color = Color::new([0.5, 0.5, 0.5, 0.3]);
+
+pub fn picking_scene() -> impl FnMut(&mut Scene, &mut SceneParams<'_>) {
+    let contents = include_str!(concat!(
+        env!("CARGO_MANIFEST_DIR"),
+        "/../assets/google_fonts/Tiger.json"
+    ));
+    let composition = Arc::new(Composition::from_slice(contents).expect("valid lottie file"));
+
+    let interactive: HashSet<String> = composition.layers.iter().map(|l| l.name.clone()).collect();
+
+    let started = Instant::now();
+    let mut renderer = Renderer::new();
+    let resolution = Vec2::new(composition.width as f64, composition.height as f64);
+
+    move |scene, params| {
+        params.resolution = Some(resolution);
+
+        let frame = ((started.elapsed().as_secs_f64() * composition.frame_rate)
+            % (composition.frames.end - composition.frames.start))
+            + composition.frames.start;
+
+        // Step 1–2: Render through the picking sink to collect per-frame bounds.
+        let mut picking = PickingScene::new(scene, interactive.clone());
+        renderer.append(&composition, frame, Affine::IDENTITY, 1.0, &mut picking);
+        let hits = picking.take_collected();
+
+        // Step 3: Convert cursor to scene coordinates and pick.
+        let scene_cursor = match (params.cursor_position, params.viewport_size) {
+            (Some(cursor), Some(viewport)) => Some(cursor_to_scene(
+                cursor,
+                viewport,
+                resolution,
+                params.camera_transform,
+            )),
+            _ => None,
+        };
+        let hovered = scene_cursor.and_then(|c| pick_layer(&hits, c));
+
+        // Step 4: Draw overlays — highlight hovered layer, dim the rest.
+        let thin_stroke = kurbo::Stroke::new(1.0);
+        let thick_stroke = kurbo::Stroke::new(3.0);
+
+        for (i, hit) in hits.iter().enumerate() {
+            let is_hovered = hovered == Some(i);
+
+            let (fill_color, stroke_color, stroke_width) = if is_hovered {
+                (HOVER_FILL, HOVER_STROKE, &thick_stroke)
+            } else {
+                (DIM_FILL, DIM_STROKE, &thin_stroke)
+            };
+
+            scene.fill(Fill::NonZero, Affine::IDENTITY, fill_color, None, &hit.rect);
+            scene.stroke(
+                stroke_width,
+                Affine::IDENTITY,
+                stroke_color,
+                None,
+                &hit.rect,
+            );
+
+            let text_color = if is_hovered {
+                Color::WHITE
+            } else {
+                Color::new([1.0, 1.0, 1.0, 0.5])
+            };
+            let text_size = if is_hovered { 16.0 } else { 12.0 };
+            params.text.add(
+                scene,
+                None,
+                text_size,
+                Some(&Brush::Solid(text_color)),
+                Affine::translate((hit.rect.x0 + 4.0, hit.rect.y0 + text_size as f64 + 2.0)),
+                &hit.name,
+            );
+        }
+
+        // Tooltip: show hovered layer name at cursor (in scene coordinates).
+        if let (Some(idx), Some(cursor)) = (hovered, scene_cursor) {
+            params.text.add(
+                scene,
+                None,
+                20.0,
+                Some(&Brush::Solid(Color::WHITE)),
+                Affine::translate((cursor.x + 16.0, cursor.y - 8.0)),
+                &format!("-> {}", hits[idx].name),
+            );
+        }
+    }
+}
+
+fn cursor_to_scene(cursor: Vec2, viewport: Vec2, resolution: Vec2, camera: Affine) -> Point {
+    let scale_factor = (viewport.x / resolution.x).min(viewport.y / resolution.y);
+    let full_transform = camera * Affine::scale(scale_factor);
+    let inverse = full_transform.inverse();
+    inverse * Point::new(cursor.x, cursor.y)
+}
+
+fn pick_layer(hits: &[LayerHit], cursor: Point) -> Option<usize> {
+    hits.iter()
+        .enumerate()
+        .filter(|(_, hit)| hit.rect.contains(cursor))
+        .max_by_key(|(_, hit)| hit.paint_order)
+        .map(|(i, _)| i)
+}
+
+/// A [`RenderSink`] wrapper around a vello [`Scene`] that intercepts draw calls
+/// to track per-layer bounding boxes while still forwarding everything to vello
+/// for normal rendering.
+struct PickingScene<'a> {
+    scene: &'a mut Scene,
+    tracker: LayerBoundsTracker,
+}
+
+impl<'a> PickingScene<'a> {
+    fn new(scene: &'a mut Scene, interactive_layers: HashSet<String>) -> Self {
+        Self {
+            scene,
+            tracker: LayerBoundsTracker::new(interactive_layers),
+        }
+    }
+
+    fn take_collected(&mut self) -> Vec<LayerHit> {
+        self.tracker.take_collected()
+    }
+}
+
+impl RenderSink for PickingScene<'_> {
+    fn push_layer(
+        &mut self,
+        blend: impl Into<BlendMode>,
+        alpha: f32,
+        transform: Affine,
+        shape: &impl Shape,
+    ) {
+        self.scene
+            .push_layer(Fill::NonZero, blend, alpha, transform, shape);
+    }
+
+    fn push_clip_layer(&mut self, transform: Affine, shape: &impl Shape) {
+        self.scene.push_clip_layer(Fill::NonZero, transform, shape);
+    }
+
+    fn pop_layer(&mut self) {
+        self.scene.pop_layer();
+    }
+
+    fn draw(
+        &mut self,
+        stroke: Option<&fixed::Stroke>,
+        transform: Affine,
+        brush: &fixed::Brush,
+        shape: &impl Shape,
+    ) {
+        if self.tracker.is_inside_tracked_layer() {
+            let bbox = shape.bounding_box();
+            let transformed = transform.transform_rect_bbox(bbox);
+            self.tracker.accumulate_bounds(transformed);
+        }
+
+        if let Some(stroke) = stroke {
+            self.scene.stroke(stroke, transform, brush, None, shape);
+        } else {
+            self.scene
+                .fill(Fill::NonZero, transform, brush, None, shape);
+        }
+    }
+
+    fn begin_layer_group(&mut self, name: &str, _index: usize) {
+        self.tracker.begin_layer_group(name);
+    }
+
+    fn end_layer_group(&mut self) {
+        self.tracker.end_layer_group();
+    }
+}
+
+struct LayerHit {
+    name: String,
+    rect: Rect,
+    paint_order: usize,
+}
+
+/// State machine that tracks bounding boxes while walking the layer tree.
+///
+/// The lifecycle for each tracked layer is:
+/// `begin_layer` → accumulate draw calls → `end_layer` → push to `collected`.
+///
+/// Nested sub-layers (precomps) are counted via `nesting` so that only the
+/// outermost tracked layer produces a [`LayerHit`].
+struct LayerBoundsTracker {
+    interactive_layers: HashSet<String>,
+    current_layer: Option<String>,
+    current_paint_order: usize,
+    current_bounds: Option<Rect>,
+    nesting: usize,
+    /// Monotonic counter — incremented on every `begin_layer_group`.
+    counter: usize,
+    collected: Vec<LayerHit>,
+}
+
+impl LayerBoundsTracker {
+    fn new(interactive_layers: HashSet<String>) -> Self {
+        Self {
+            interactive_layers,
+            current_layer: None,
+            current_paint_order: 0,
+            current_bounds: None,
+            nesting: 0,
+            counter: 0,
+            collected: Vec::new(),
+        }
+    }
+
+    fn is_inside_tracked_layer(&self) -> bool {
+        self.current_layer.is_some()
+    }
+
+    fn begin_layer_group(&mut self, name: &str) {
+        self.counter += DEPTH_BAND;
+        if self.current_layer.is_some() {
+            self.nesting += 1;
+            return;
+        }
+        if self.interactive_layers.contains(name) {
+            self.current_layer = Some(name.to_string());
+            self.current_paint_order = self.counter;
+            self.current_bounds = None;
+            self.nesting = 0;
+        }
+    }
+
+    fn accumulate_bounds(&mut self, rect: Rect) {
+        if self.current_layer.is_some() {
+            self.current_bounds = Some(match self.current_bounds {
+                Some(existing) => existing.union(rect),
+                None => rect,
+            });
+        }
+    }
+
+    fn end_layer_group(&mut self) {
+        if self.current_layer.is_none() {
+            return;
+        }
+        if self.nesting > 0 {
+            self.nesting -= 1;
+            return;
+        }
+        if let Some(name) = self.current_layer.take()
+            && let Some(rect) = self.current_bounds.take()
+        {
+            self.collected.push(LayerHit {
+                name,
+                rect,
+                paint_order: self.current_paint_order,
+            });
+        }
+    }
+
+    fn take_collected(&mut self) -> Vec<LayerHit> {
+        std::mem::take(&mut self.collected)
+    }
+}

--- a/examples/scenes/src/test_scenes.rs
+++ b/examples/scenes/src/test_scenes.rs
@@ -29,6 +29,7 @@ macro_rules! scene {
 pub fn test_scenes() -> SceneSet {
     let scenes = vec![
         scene!(splash_with_tiger(), "Tiger", true),
+        scene!(crate::picking::picking_scene(), "Picking", true),
         scene!(polystar_test(), "PolyStarTest", true),
     ];
     SceneSet { scenes }

--- a/examples/with_winit/src/lib.rs
+++ b/examples/with_winit/src/lib.rs
@@ -345,6 +345,9 @@ fn run(
                             base_color: None,
                             interactive: true,
                             complexity,
+                            cursor_position: prior_position,
+                            viewport_size: Some(Vec2::new(width as f64, height as f64)),
+                            camera_transform: transform,
                         };
                         example_scene
                             .function

--- a/src/runtime/render.rs
+++ b/src/runtime/render.rs
@@ -31,6 +31,15 @@ pub trait RenderSink {
         brush: &fixed::Brush,
         shape: &impl kurbo::Shape,
     );
+
+    /// Called before rendering a Lottie layer.
+    ///
+    /// - `name` is the layer's `nm` field.
+    /// - `index` is the layer's position in the layer array.
+    fn begin_layer_group(&mut self, _name: &str, _index: usize) {}
+
+    /// Called after rendering a Lottie layer.
+    fn end_layer_group(&mut self) {}
 }
 
 /// Renders a composition into a scene.
@@ -60,7 +69,7 @@ impl Renderer {
             transform,
             &Rect::new(0.0, 0.0, animation.width as _, animation.height as _),
         );
-        for layer in animation.layers.iter().rev() {
+        for (layer_index, layer) in animation.layers.iter().enumerate().rev() {
             if layer.is_mask {
                 continue;
             }
@@ -68,6 +77,7 @@ impl Renderer {
                 animation,
                 &animation.layers,
                 layer,
+                layer_index,
                 transform,
                 alpha,
                 frame,
@@ -83,6 +93,7 @@ impl Renderer {
         animation: &Composition,
         layer_set: &[Layer],
         layer: &Layer,
+        layer_index: usize,
         transform: Affine,
         alpha: f64,
         frame: f64,
@@ -91,6 +102,7 @@ impl Renderer {
         if !layer.frames.contains(&frame) {
             return;
         }
+        scene.begin_layer_group(&layer.name, layer_index);
         let parent_transform = transform;
         let transform = self.compute_transform(layer_set, layer, parent_transform, frame);
         let full_rect = Rect::new(0.0, 0.0, animation.width as f64, animation.height as f64);
@@ -104,6 +116,7 @@ impl Renderer {
                     animation,
                     layer_set,
                     mask,
+                    0,
                     parent_transform,
                     alpha,
                     frame,
@@ -140,6 +153,7 @@ impl Renderer {
                             animation,
                             asset_layers,
                             asset_layer,
+                            0,
                             transform,
                             alpha,
                             frame + frame_delta,
@@ -157,6 +171,7 @@ impl Renderer {
         for _ in 0..layer.masks.len() + (layer.mask_layer.is_some() as usize * 2) {
             scene.pop_layer();
         }
+        scene.end_layer_group();
     }
 
     fn render_shapes(&mut self, shapes: &[Shape], transform: Affine, alpha: f64, frame: f64) {


### PR DESCRIPTION
Adds default-empty `begin_layer_group(name, index)` / `end_layer_group()` methods, called around each top-level layer's draw calls (including masks and precomp expansions). Lets consumers associate draws with their source layer for hit-testing, overlays, or per-layer post-processing without re-walking the tree.

Adds picking scene demonstrating layer group hooks

**AI Notice**

The example code was generated by Claude Opus 4.6 a while ago, it based it off my original game code.