### PR TITLE
fix: surface inner errors from AnyAsset deserialization

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ This release has an [MSRV][] of 1.88.
 ### Fixed
 
 - Fixed `with_winit` example failing to start due to `wgpu` version mismatch (v26 vs v27) left behind during the Vello 0.7 upgrade. ([#100][] by [@RobertBrewitz][])
+- Fixed `AnyAsset` deserialization errors not naming the failing asset. Errors now include the asset id, and also forward the actual inner failure (e.g. an unknown shape variant inside a precomposition's layers) instead of the generic "did not match any variant of untagged enum" message. ([#105][] by [@RobertBrewitz][])
 
 ## [0.9.0]
 
@@ -179,6 +180,7 @@ This release has an [MSRV][] of 1.75.
 [#95]: https://github.com/linebender/velato/pull/95
 [#96]: https://github.com/linebender/velato/pull/96
 [#100]: https://github.com/linebender/velato/pull/100
+[#105]: https://github.com/linebender/velato/pull/105
 
 [Unreleased]: https://github.com/linebender/velato/compare/v0.9.0...HEAD
 [0.9.0]: https://github.com/linebender/velato/compare/v0.8.1...v0.9.0

--- a/src/schema/assets/mod.rs
+++ b/src/schema/assets/mod.rs
@@ -8,13 +8,48 @@ pub mod precomposition;
 
 use self::image::Image;
 use self::precomposition::Precomposition;
-use serde::{Deserialize, Serialize};
+use serde::{Deserialize, Deserializer, Serialize};
 
-#[derive(Deserialize, Serialize, Debug, Clone, PartialEq)]
+#[derive(Serialize, Debug, Clone, PartialEq)]
 #[serde(untagged)]
 pub enum AnyAsset {
     Image(Image),
     Precomposition(Precomposition),
     // unimplemented - Sound(Sound),
     // unimplemented - DataSource(DataSource),
+}
+
+impl<'de> Deserialize<'de> for AnyAsset {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        use serde::de::Error;
+
+        let value = serde_json::Value::deserialize(deserializer)?;
+        let id = value
+            .get("id")
+            .and_then(|v| v.as_str())
+            .unwrap_or("<unknown>")
+            .to_owned();
+
+        // Lottie assets have no single discriminator field
+        if value.get("layers").is_some() {
+            serde_json::from_value(value)
+                .map(AnyAsset::Precomposition)
+                .map_err(|e| D::Error::custom(format!("asset id={id:?} (Precomposition): {e}")))
+        } else if value.get("t").and_then(|v| v.as_u64()) == Some(3) {
+            Err(D::Error::custom(format!(
+                "asset id={id:?}: DataSource asset not yet supported"
+            )))
+        } else if value.get("w").is_some() || value.get("h").is_some() {
+            serde_json::from_value(value)
+                .map(AnyAsset::Image)
+                .map_err(|e| D::Error::custom(format!("asset id={id:?} (Image): {e}")))
+        } else {
+            Err(D::Error::custom(format!(
+                "asset id={id:?}: Sound asset not yet supported"
+            )))
+        }
+    }
 }


### PR DESCRIPTION
Lottie assets have no discriminator field (the spec discriminates them structurally). Replace `#[serde(untagged)]` on `AnyAsset` with a custom `Deserialize` that classifies by structure and forwards the chosen variant's error, prefixed with the asset id. Mirrors the pattern `AnyLayer` already uses.